### PR TITLE
Feat/13 header fix

### DIFF
--- a/src/components/layout/ShopLayout.tsx
+++ b/src/components/layout/ShopLayout.tsx
@@ -1,12 +1,10 @@
 import Footer from '@/components/ui/Footer';
 import Header from '@/components/ui/Header';
-import { useOverlay } from '@/context/overlayContext';
 import type { MenuItem } from '@/types/headerTypes';
 import { BookIcon, ShoppingCartIcon, UserCircleIcon } from '@phosphor-icons/react';
 import { Outlet } from 'react-router-dom';
 
 export default function ShopLayout() {
-  const { isOverlay } = useOverlay();
   const menus: MenuItem[] = [
     { id: 1, to: '/books', label: 'books', Icon: BookIcon },
     { id: 2, to: '/cart', label: 'cart', Icon: ShoppingCartIcon },
@@ -19,10 +17,6 @@ export default function ShopLayout() {
         <Outlet />
       </main>
       <Footer menus={menus} />
-
-      <div
-        className={`fixed inset-0 z-40 bg-black/50 transition-opacity ${isOverlay ? 'opacity-100 delay-0 duration-300' : 'pointer-events-none opacity-0 delay-150 duration-150'} `}
-      />
     </div>
   );
 }

--- a/src/components/menu/MenuList.tsx
+++ b/src/components/menu/MenuList.tsx
@@ -1,17 +1,17 @@
 import type { MenuItem } from '@/types/headerTypes';
 import Menu from './Menu';
 
-type Props = { menus: MenuItem[]; isMobile?: boolean };
+type MenuListProps = { menus: MenuItem[]; isVertical?: boolean };
 
-export default function MenuList({ menus, isMobile }: Props) {
+export default function MenuList({ menus, isVertical }: MenuListProps) {
   return (
     <ul
-      className={`h-full items-center gap-1 ${isMobile ? 'flex flex-col md:hidden' : 'hidden md:flex'} `}
+      className={`h-full items-center gap-1 ${isVertical ? 'flex flex-col md:hidden' : 'hidden md:flex'} `}
     >
       {menus.map(({ id, to, label, Icon }) => (
         <Menu key={id} to={to}>
           <Icon size={18} weight="light" />
-          <span className={`${isMobile ? '' : 'hidden'}`}>{label}</span>
+          <span className={`${isVertical ? '' : 'hidden'}`}>{label}</span>
         </Menu>
       ))}
     </ul>

--- a/src/components/ui/Header.tsx
+++ b/src/components/ui/Header.tsx
@@ -46,7 +46,7 @@ export default function Header({ menus }: Props) {
       </header>
 
       <div
-        className={`bg-whitetransition-transform fixed top-0 right-0 z-50 flex h-full w-64 transform flex-col gap-2 duration-300 ${open ? 'translate-x-0' : 'translate-x-full'} `}
+        className={`fixed top-0 right-0 z-50 flex h-full w-64 transform flex-col gap-2 bg-white transition-transform duration-300 ${open ? 'translate-x-0' : 'translate-x-full'} `}
       >
         <div className="flex-end h-16 border-b px-2">
           <button

--- a/src/components/ui/Header.tsx
+++ b/src/components/ui/Header.tsx
@@ -1,6 +1,6 @@
 import { NavLink } from 'react-router-dom';
 import SearchInput from '@/components/ui/SearchInput';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { ListIcon, XIcon } from '@phosphor-icons/react';
 import type { MenuItem } from '@/types/headerTypes';
 import { useOverlay } from '@/context/overlayContext';
@@ -14,6 +14,17 @@ export default function Header({ menus }: Props) {
     setOpen(!open);
     setOverlay(!isOverlay);
   };
+
+  useEffect(() => {
+    const handleResize = () => {
+      if (window.innerWidth >= 768) {
+        setOpen(false);
+        setOverlay(false);
+      }
+    };
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, [setOverlay]);
 
   return (
     <>
@@ -58,9 +69,17 @@ export default function Header({ menus }: Props) {
           </button>
         </div>
         <div className="px-2">
-          <MenuList menus={menus} isMobile={true} />
+          <MenuList menus={menus} isVertical />
         </div>
       </div>
+
+      <div
+        className={`fixed inset-0 z-40 bg-black/50 transition-opacity ${isOverlay ? 'opacity-100 delay-0 duration-300' : 'pointer-events-none opacity-0 delay-150 duration-150'} `}
+        onClick={() => {
+          setOpen(false);
+          setOverlay(false);
+        }}
+      />
     </>
   );
 }


### PR DESCRIPTION
<!--
PR 제목 규칙(권장): [Type/Scope] 요약
예) [Chore/Setup] 이슈/PR 템플릿 도입
    [Feat/Header] 헤더 마크업 및 반응형
    [Fix/Auth] 토큰 만료시 무한 401 수정
-->

Closes #13 

## 개요

- 모바일 헤더 배경 사라짐
- 모바일 헤더 오픈 후 화면 리사이즈시 모바일 헤더 레이아웃이 유지됨
- 오버레이 창 클릭시 헤더가 닫히지 않음

## 변경 사항

- 오버레이 위치 Header 컴포넌트로 변경(props drilling 방지)
- useEffect 사용하여 리사이즈 처리


## 테스트/확인 방법

- npm run dev 실행
- 768 사이즈 이하로 줄인후 모바일 헤더 오픈하여 리사이즈 및 오버레이 클릭

## 체크리스트

- [x] 로컬 동작 확인
- [x] `npm run lint` / `npm run format` 통과
- [x] 최신 dev 기준 rebase 완료 (충돌 해결)
- [x] 접근성/반응형 확인(해당 시)
- [x] 문서/주석 보강(해당 시)

## 추가 참고(선택)

- 기술적 트레이드오프/대안, 후속 작업 이슈 링크 등
