### PR TITLE
feat: book list 페이지 작업

### DIFF
--- a/src/components/books/BookCategories.tsx
+++ b/src/components/books/BookCategories.tsx
@@ -1,0 +1,37 @@
+import { listCategories } from '@/constants/listCategory';
+
+type BookCategoriesProps = {
+  selectedId: number;
+  onSelect: (id: number) => void;
+};
+
+export default function BookCategories({ selectedId, onSelect }: BookCategoriesProps) {
+  return (
+    <aside className="border-r pr-4">
+      <ul className="space-y-5">
+        {listCategories.map((parent) => (
+          <li key={parent.id}>
+            {/* 부모 카테고리 */}
+            <h3 className="mb-2 text-base font-semibold text-gray-800">{parent.name}</h3>
+
+            {/* 자식 카테고리 */}
+            <ul className="ml-3 space-y-2 border-l pl-3">
+              {parent.children.map((child) => (
+                <li key={child.id}>
+                  <button
+                    onClick={() => onSelect(child.id)}
+                    className={`w-full text-left text-sm hover:text-emerald-600 ${
+                      selectedId === child.id ? 'font-semibold text-emerald-700' : 'text-gray-600'
+                    }`}
+                  >
+                    {child.name}
+                  </button>
+                </li>
+              ))}
+            </ul>
+          </li>
+        ))}
+      </ul>
+    </aside>
+  );
+}

--- a/src/components/books/BookList.tsx
+++ b/src/components/books/BookList.tsx
@@ -1,10 +1,39 @@
-import BookCard from './BookCard';
+import BookCategories from './BookCategories';
+import BookListItem from './BookListItem';
+import { useAladinQuery } from '@/hooks/useAladinQuery';
+import type { AladinResponse } from '@/types/aladinTypes';
+import { useSearchParams } from 'react-router-dom';
 
 export default function BookList() {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const categoryId = Number(searchParams.get('category') || 0);
+
+  const { data, isLoading, error } = useAladinQuery<AladinResponse>(
+    ['books', categoryId],
+    'ItemList.aspx',
+    {
+      QueryType: 'Bestseller',
+      CategoryId: categoryId,
+      MaxResults: 20,
+      SearchTarget: 'Book',
+      cover: 'MidBig',
+    },
+  );
+
   return (
-    <>
-      book list
-      <BookCard />
-    </>
+    <section className="grid grid-cols-[220px_1fr] gap-6">
+      <BookCategories
+        selectedId={categoryId}
+        onSelect={(id) => setSearchParams({ category: String(id) })}
+      />
+
+      <div className="space-y-6">
+        {isLoading && <p>로딩중...</p>}
+        {error && <p>에러 발생</p>}
+        {data?.item.map((book) => (
+          <BookListItem key={book.itemId} book={book} />
+        ))}
+      </div>
+    </section>
   );
 }

--- a/src/components/books/BookListItem.tsx
+++ b/src/components/books/BookListItem.tsx
@@ -1,0 +1,38 @@
+import type { AladinBook } from '@/types/aladinTypes';
+
+type BookListItemProps = { book: AladinBook };
+
+export default function BookListItem({ book }: BookListItemProps) {
+  return (
+    <div className="flex gap-6 border-b pb-6 last:border-0">
+      <img
+        src={book.cover}
+        alt={book.title}
+        className="h-40 w-28 shrink-0 rounded-md object-cover shadow"
+      />
+      <div className="flex flex-col justify-between">
+        <div>
+          <h3 className="text-lg font-semibold">{book.title}</h3>
+          <p className="text-sm text-gray-500">{book.author}</p>
+          <p className="mt-2 line-clamp-2 text-sm text-gray-700">
+            {book.description || '설명이 없습니다.'}
+          </p>
+        </div>
+        <div className="mt-3 flex items-center gap-4 text-sm">
+          {book.priceSales && book.priceSales < book.priceStandard ? (
+            <>
+              <span className="font-bold text-emerald-700">
+                {book.priceSales.toLocaleString()}원
+              </span>
+              <span className="text-gray-400 line-through">
+                {book.priceStandard.toLocaleString()}원
+              </span>
+            </>
+          ) : (
+            <span className="font-bold text-gray-900">{book.priceStandard.toLocaleString()}원</span>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/constants/listCategory.ts
+++ b/src/constants/listCategory.ts
@@ -1,0 +1,31 @@
+export const listCategories = [
+  {
+    id: 1,
+    name: '국내도서',
+    children: [
+      { id: 74, name: '소설/시/희곡' },
+      { id: 55889, name: '에세이' },
+      { id: 1108, name: '경제경영' },
+      { id: 1322, name: '어린이' },
+      { id: 656, name: '자기계발' },
+    ],
+  },
+  {
+    id: 336,
+    name: 'eBook',
+    children: [
+      { id: 112011, name: '여행' },
+      { id: 132041, name: '요리' },
+      { id: 55890, name: '만화' },
+    ],
+  },
+  {
+    id: 50917,
+    name: '청소년',
+    children: [
+      { id: 987, name: '사회과학' },
+      { id: 517, name: '과학' },
+      { id: 4395, name: '역사' },
+    ],
+  },
+];

--- a/src/pages/BooksPage.tsx
+++ b/src/pages/BooksPage.tsx
@@ -1,0 +1,9 @@
+import BookList from '@/components/books/BookList';
+
+export default function BooksPage() {
+  return (
+    <div className="my-28">
+      <BookList />
+    </div>
+  );
+}

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -1,12 +1,14 @@
 import { createBrowserRouter } from 'react-router-dom';
 import ShopLayout from './components/layout/ShopLayout';
 import HomePage from '@/pages/HomePage';
+import BooksPage from './pages/BooksPage';
 
 const router = createBrowserRouter([
   {
     element: <ShopLayout />,
     children: [
       { path: '/', element: <HomePage /> },
+      { path: '/books', element: <BooksPage /> },
       { path: '*', element: <div className="p-6">Not Found</div> },
     ],
   },

--- a/src/types/aladinTypes.ts
+++ b/src/types/aladinTypes.ts
@@ -1,4 +1,5 @@
 export type AladinBook = {
+  itemId: string;
   title: string;
   link: string;
   cover: string;
@@ -7,6 +8,8 @@ export type AladinBook = {
   description: string;
   pubDate: string;
   isbn13: string;
+  priceSales: string;
+  priceStandard: string;
 };
 
 export type AladinResponse = {


### PR DESCRIPTION
<!--
PR 제목 규칙(권장): [Type/Scope] 요약
예) [Chore/Setup] 이슈/PR 템플릿 도입
    [Feat/Header] 헤더 마크업 및 반응형
    [Fix/Auth] 토큰 만료시 무한 401 수정
-->

Closes #16

## 개요

- 북 리스트 페이지 작업
- 카테고리 id 노출
- 카테고리의 맞는 책 리스트 출력

## 변경 사항

- BookList 컴포넌트에서 리스트 페이지 구현

## 스크린샷/동영상 (선택)

<img width="1347" height="677" alt="image" src="https://github.com/user-attachments/assets/6a218349-c847-4f98-b189-b992aa50e0fc" />

## 테스트/확인 방법

 - npm run dev 실행

## 체크리스트

- [x] 로컬 동작 확인
- [x] `npm run lint` / `npm run format` 통과
- [x] 최신 dev 기준 rebase 완료 (충돌 해결)
- [x] 접근성/반응형 확인(해당 시)
- [x] 문서/주석 보강(해당 시)

## 추가 참고(선택)

- 기술적 트레이드오프/대안, 후속 작업 이슈 링크 등
